### PR TITLE
add .bowerrc 

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "components"
+}


### PR DESCRIPTION
in order to set default bower directory for different versions of bower
